### PR TITLE
Implement reasoning model interfaces

### DIFF
--- a/code-memory-harness/src/ai_integration/claude_reasoning.py
+++ b/code-memory-harness/src/ai_integration/claude_reasoning.py
@@ -1,0 +1,50 @@
+import json
+import anthropic
+
+from .model_interface import ReasoningModelInterface
+
+class ClaudeReasoningModel(ReasoningModelInterface):
+    """Claude-3 Opus integration with advanced reasoning"""
+
+    def __init__(self, api_key: str):
+        self.client = anthropic.AsyncAnthropic(api_key=api_key)
+        self.model = "claude-3-opus-20240229"
+
+    async def generate_fix(self, error_context, code_context, memory_context):
+        # Claude excels at nuanced code understanding
+        prompt = f"""
+        <error_analysis>
+        Error Details: {json.dumps(error_context)}
+        
+        Retrieved Code Context:
+        ```
+        {code_context}
+        ```
+        
+        Historical Fixes for Similar Errors:
+        {self._format_memory_context(memory_context)}
+        </error_analysis>
+        
+        Please analyze this error using systematic reasoning:
+        1. Identify the error category and root cause
+        2. Evaluate if historical fixes apply
+        3. Propose a fix that maintains code consistency
+        4. Explain potential side effects
+        """
+
+        response = await self.client.messages.create(
+            model=self.model,
+            max_tokens=2000,
+            messages=[{"role": "user", "content": prompt}]
+        )
+
+        return response.content[0].text
+
+    async def generate_tests(self, function_code: str, test_strategy: str):
+        raise NotImplementedError("Test generation not implemented")
+
+    async def validate_memory(self, memory_item, current_code: str):
+        raise NotImplementedError("Memory validation not implemented")
+
+    def _format_memory_context(self, memory_context):
+        return "\n".join(json.dumps(item) for item in memory_context[:3])

--- a/code-memory-harness/src/ai_integration/model_interface.py
+++ b/code-memory-harness/src/ai_integration/model_interface.py
@@ -1,0 +1,21 @@
+from abc import ABC, abstractmethod
+from typing import Dict, List, Optional
+
+class ReasoningModelInterface(ABC):
+    """Abstract interface for reasoning models"""
+
+    @abstractmethod
+    async def generate_fix(self, error_context: Dict,
+                           code_context: str,
+                           memory_context: List[Dict]) -> str:
+        pass
+
+    @abstractmethod
+    async def generate_tests(self, function_code: str,
+                             test_strategy: str) -> List[str]:
+        pass
+
+    @abstractmethod
+    async def validate_memory(self, memory_item: Dict,
+                              current_code: str) -> float:
+        pass

--- a/code-memory-harness/src/ai_integration/openai_reasoning.py
+++ b/code-memory-harness/src/ai_integration/openai_reasoning.py
@@ -1,0 +1,44 @@
+from openai import AsyncOpenAI
+import json
+
+from .model_interface import ReasoningModelInterface
+
+class OpenAIReasoningModel(ReasoningModelInterface):
+    """OpenAI o1 model integration"""
+
+    def __init__(self, api_key: str):
+        self.client = AsyncOpenAI(api_key=api_key)
+        self.model = "o1-preview"  # or "o1-mini" for faster/cheaper
+
+    async def generate_fix(self, error_context, code_context, memory_context):
+        # o1 models excel at reasoning through complex problems
+        prompt = f"""
+        Analyze this error and provide a fix using chain-of-thought reasoning:
+        
+        Error: {json.dumps(error_context)}
+        
+        Relevant Code Context (retrieved via RAG):
+        {code_context}
+        
+        Previous Similar Fixes:
+        {json.dumps(memory_context[:3])}  # Limit to fit context
+        
+        Reason through:
+        1. Root cause analysis
+        2. Why previous fixes might/might not apply
+        3. Optimal solution considering the codebase patterns
+        """
+
+        response = await self.client.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.1  # Lower temperature for reasoning tasks
+        )
+
+        return response.choices[0].message.content
+
+    async def generate_tests(self, function_code: str, test_strategy: str):
+        raise NotImplementedError("Test generation not implemented")
+
+    async def validate_memory(self, memory_item, current_code: str):
+        raise NotImplementedError("Memory validation not implemented")


### PR DESCRIPTION
## Summary
- define `ReasoningModelInterface` for async reasoning tasks
- implement OpenAI reasoning model
- implement Claude reasoning model

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d61a610e48329896cacfc0068fb9c