### PR TITLE
Implement basic performance benchmarking class

### DIFF
--- a/code-memory-harness/src/validation/benchmark_suite.py
+++ b/code-memory-harness/src/validation/benchmark_suite.py
@@ -1,0 +1,51 @@
+import time
+import numpy as np
+
+
+class PerformanceBenchmark:
+    """Measure system performance metrics"""
+
+    def __init__(self, engine):
+        self.engine = engine
+
+    async def run_benchmarks(self):
+        benchmarks = {
+            "indexing_speed": self.benchmark_indexing,
+            "retrieval_latency": self.benchmark_retrieval,
+            "context_compression": self.benchmark_compression,
+            "fix_generation_time": self.benchmark_fix_generation,
+            "memory_overhead": self.benchmark_memory_usage,
+        }
+
+        results = {}
+        for name, benchmark in benchmarks.items():
+            print(f"Running {name} benchmark...")
+            results[name] = await benchmark()
+
+        return results
+
+    async def benchmark_indexing(self):
+        raise NotImplementedError("Indexing benchmark not implemented")
+
+    async def benchmark_compression(self):
+        raise NotImplementedError("Compression benchmark not implemented")
+
+    async def benchmark_fix_generation(self):
+        raise NotImplementedError("Fix generation benchmark not implemented")
+
+    async def benchmark_memory_usage(self):
+        raise NotImplementedError("Memory usage benchmark not implemented")
+
+    async def benchmark_retrieval(self):
+        """Target: <100ms for 95th percentile"""
+        latencies = []
+        for _ in range(100):
+            start = time.time()
+            await self.engine.retrieve("test query")
+            latencies.append(time.time() - start)
+
+        return {
+            "p50": np.percentile(latencies, 50),
+            "p95": np.percentile(latencies, 95),
+            "p99": np.percentile(latencies, 99),
+        }


### PR DESCRIPTION
## Summary
- implement `PerformanceBenchmark` skeleton in validation module
- include retrieval latency benchmark with 50/95/99th percentile output
- provide placeholders for other benchmarks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d6d378ec883299211a892dc78d9c0