### PR TITLE
Add Python Dockerfile

### DIFF
--- a/code-memory-harness/docker/Dockerfile
+++ b/code-memory-harness/docker/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy source code
+COPY . .
+
+# Run validation suite
+CMD ["python", "scripts/run_validation.py"]


### PR DESCRIPTION
## Summary
- add Dockerfile in `code-memory-harness/docker` to build a Python 3.11 runtime

## Testing
- `python -m pytest`
- `python code-memory-harness/scripts/run_validation.py` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685d6eb684f48329a89dc262eb9d8422